### PR TITLE
Improve link contrast

### DIFF
--- a/style.css
+++ b/style.css
@@ -13,7 +13,7 @@ main {
 }
 
 a {
-    color: #30475E;
+    color: #77b2ee;
 }
 
 h1 {


### PR DESCRIPTION
Make links a lighter colour, so they are legible against the black background.

The new colour gives a contrast oi:

* 5.73:1 in the worst case (against the lightest colour of the gradient), which meets the [WCAG AA minimum contrast requirements](https://www.w3.org/TR/WCAG21/#contrast-minimum).
* 8.24:1 in the best case (against the darkest colour of the gradient), which meets the [WCAG AAA enhanced contrast requirements](https://www.w3.org/TR/WCAG21/#contrast-enhanced).