### PR TITLE
Avoid making page larger than screen when it fits

### DIFF
--- a/style.css
+++ b/style.css
@@ -1,15 +1,20 @@
+* {
+    box-sizing: border-box;
+}
+
 body {
     font: 400 16px "Roboto", "Helvetica Neue", "Helvetica", sans-serif;
     background: linear-gradient(0deg, rgb(50, 50, 50) 0%, rgb(20, 20, 20) 100%);
     margin: 0;
     min-height: 100vh;
     color: rgb(255, 255, 255);
+    padding: 5em 0 2em;
 }
 
 main {
     width: 90vw;
     max-width: 33em;
-    margin: 5em auto 0;
+    margin: 0 auto;
 }
 
 a {


### PR DESCRIPTION
This also makes the browser hide scrollbars when the page fits on the screen. Setting `overflow-y: scroll;` on `body` may be desirable to prevent elements present on all pages from moving around when navigating from a page without a scrollbar to one with a scrollbar (or vice versa).